### PR TITLE
Fix crash when merging labels in A6 mode

### DIFF
--- a/src/PostNL.php
+++ b/src/PostNL.php
@@ -870,11 +870,11 @@ class PostNL implements LoggerAwareInterface
                     } elseif ($a6Orientation === 'P' && $sizes['orientation'] === 'L') {
                         $pdf->rotateCounterClockWise();
                     }
-                    $pdf->setSourceFile(\ThirtyBeesPostNL\setasign\Fpdi\PdfParser\StreamReader::createByString($pdfContent));
+                    $pdf->setSourceFile(StreamReader::createByString($pdfContent));
                     $pdf->useTemplate($pdf->importPage(1), $correction[0], $correction[1]);
                 } else {
                     // Assuming A4 here (could be multi-page) - defer to end
-                    $stream = \ThirtyBeesPostNL\setasign\Fpdi\PdfParser\StreamReader::createByString($pdfContent);
+                    $stream = StreamReader::createByString($pdfContent);
                     $deferred[] = ['stream' => $stream, 'sizes' => $sizes];
                 }
             }

--- a/tests/Service/LabellingServiceRestTest.php
+++ b/tests/Service/LabellingServiceRestTest.php
@@ -283,12 +283,12 @@ class LabellingServiceRestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox can generate multiple labels
+     * @testdox can generate multiple A4-merged labels
      *
      * @throws \setasign\Fpdi\PdfReader\PdfReaderException
      * @throws \Exception
      */
-    public function testMergeMultipleLabelsRest()
+    public function testMergeMultipleA4LabelsRest()
     {
         $mock = new MockHandler([
             new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
@@ -389,6 +389,124 @@ class LabellingServiceRestTest extends \PHPUnit_Framework_TestCase
             true,
             true,
             Label::FORMAT_A4,
+            [
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+            ]
+        );
+
+        $this->assertTrue(is_string($label));
+    }
+
+    /**
+     * @testdox can generate multiple A6-merged labels
+     *
+     * @throws \setasign\Fpdi\PdfReader\PdfReaderException
+     * @throws \Exception
+     */
+    public function testMergeMultipleA6LabelsRest()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611210',
+                        'DownPartnerLocation' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611211',
+                        'DownPartnerLocation' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $mockClient = new MockClient();
+        $mockClient->setHandler($handler);
+        $this->postnl->setHttpClient($mockClient);
+
+        $label = $this->postnl->generateLabels([
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setBarcode('3SDEVC201611210')
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085'),
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setBarcode('3SDEVC201611211')
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085'),
+        ],
+            'GraphicFile|PDF',
+            true,
+            true,
+            Label::FORMAT_A6,
             [
                 1 => true,
                 2 => true,


### PR DESCRIPTION
This fixes an issue where a non-existing class was referenced when merging (multiple) labels in A6 format.

Added an additional tests which will cover at least some of the A6 path in the code.