### PR TITLE
Add new PostNL Shipping webservice v1

### DIFF
--- a/docs/services.rst
+++ b/docs/services.rst
@@ -713,3 +713,78 @@ locationsinarea
     ``GetLocationsInArea`` - `required`
 
     The `GetLocationsInArea` request object. See the API documentation for more details.
+
+Shipping service
+----------------
+
+.. note::
+
+    | PostNL API documentation for this service:
+    | https://developer.postnl.nl/browse-apis/send-and-track/shipping-webservice/
+
+The shipping service combines all the functionality of the labeling, confirming, barcode and easy return service.
+The service is only available as REST.
+
+Generate a single shipping
+~~~~~~~~~~~~~~~~~~~~~
+
+The following example generates a single shipment for a domestic shipment:
+
+.. code-block:: php
+
+    <?php
+    $postnl = new PostNL(...);
+    $postnl->generateShipping(
+        Shipment::create()
+            ->setAddresses([
+                Address::create([
+                    'AddressType' => '01',
+                    'City'        => 'Utrecht',
+                    'Countrycode' => 'NL',
+                    'FirstName'   => 'Peter',
+                    'HouseNr'     => '9',
+                    'HouseNrExt'  => 'a bis',
+                    'Name'        => 'de Ruijter',
+                    'Street'      => 'Bilderdijkstraat',
+                    'Zipcode'     => '3521VA',
+                ]),
+                Address::create([
+                    'AddressType' => '02',
+                    'City'        => 'Hoofddorp',
+                    'CompanyName' => 'PostNL',
+                    'Countrycode' => 'NL',
+                    'HouseNr'     => '42',
+                    'Street'      => 'Siriusdreef',
+                    'Zipcode'     => '2132WT',
+                ]),
+            ])
+            ->setDeliveryAddress('01')
+            ->setDimension(new Dimension('2000'))
+            ->setProductCodeDelivery('3085'),
+        'GraphicFile|PDF',
+        false
+    );
+
+This will create a standard shipment (product code 3085). You can access the label (base64 encoded PDF) this way:
+
+.. code-block:: php
+
+    <?php
+    $pdf = base64_decode($shipping->getResponseShipments()[0]->getLabels()[0]->getContent());
+
+This function accepts the following arguments:
+
+shipment
+    ``Shipment`` - `required`
+
+    The Shipment object. Visit the PostNL API documentation to find out what a Shipment object consists of.
+
+printertype
+    ``string`` - `optional, defaults to GraphicFile|PDF`
+
+    The list of supported printer types can be found on this page: https://developer.postnl.nl/browse-apis/send-and-track/shipping-webservice/documentation/
+
+confirm
+    ``string`` - `optional, defaults to true`
+
+    Indicates whether the shipment should immediately be confirmed.

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -788,3 +788,100 @@ confirm
     ``string`` - `optional, defaults to true`
 
     Indicates whether the shipment should immediately be confirmed.
+
+Generate multiple shipments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example shows how labels of multiple shipments can be merged:
+
+.. code-block:: php
+
+    <?php
+    $shipments = [
+        Shipment::create([
+            'Addresses'           => [
+                Address::create([
+                    'AddressType' => '01',
+                    'City'        => 'Utrecht',
+                    'Countrycode' => 'NL',
+                    'FirstName'   => 'Peter',
+                    'HouseNr'     => '9',
+                    'HouseNrExt'  => 'a bis',
+                    'Name'        => 'de Ruijter',
+                    'Street'      => 'Bilderdijkstraat',
+                    'Zipcode'     => '3521VA',
+                ]),
+            ],
+            'Dimension'           => new Dimension('1000'),
+            'ProductCodeDelivery' => '3085',
+        ]),
+        Shipment::create([
+            'Addresses'           => [
+                Address::create([
+                    'AddressType' => '01',
+                    'City'        => 'Utrecht',
+                    'Countrycode' => 'NL',
+                    'FirstName'   => 'Peter',
+                    'HouseNr'     => '9',
+                    'HouseNrExt'  => 'a bis',
+                    'Name'        => 'de Ruijter',
+                    'Street'      => 'Bilderdijkstraat',
+                    'Zipcode'     => '3521VA',
+                ]),
+            ],
+            'Dimension'           => new Dimension('1000'),
+            'ProductCodeDelivery' => '3085',
+        ]),
+    ];
+
+    $label = $postnl->generateShippings(
+        $shipments,
+        'GraphicFile|PDF', // Printertype (only PDFs can be merged -- no need to use the Merged types)
+        true, // Confirm immediately
+        true, // Merge
+        Label::FORMAT_A4, // Format -- this merges multiple A6 labels onto an A4
+        [
+            1 => true,
+            2 => true,
+            3 => true,
+            4 => true,
+        ] // Positions
+    );
+
+    file_put_contents('labels.pdf', $label);
+
+By setting the `merge` flag it will automatically merge the labels into a PDF string.
+
+The function accepts the following arguments:
+
+shipments
+    ``Shipment[]`` - `required`
+
+    The Shipment objects. Visit the PostNL API documentation to find out what a Shipment object consists of.
+
+printertype
+    ``string`` - `optional, defaults to GraphicFile|PDF`
+
+    The list of supported printer types can be found on this page: https://developer.postnl.nl/browse-apis/send-and-track/shipping-webservice/documentation/
+
+confirm
+    ``string`` - `optional, defaults to true`
+
+    Indicates whether the shipment should immediately be confirmed.
+
+merge
+    ``bool`` - `optional, default to false`
+
+    This will merge the labels and make the function return a pdf string of the merged label.
+
+format
+    ``int`` - `optional, defaults to 1 (FORMAT_A4)`
+
+    This sets the paper format (can be A4 or A4).
+
+positions
+    ``bool[]`` - `optional, defaults to all positions`
+
+    This will set the positions of the labels. The following image shows the available positions, use `true` or `false` to resp. enable or disable a position:
+
+.. image:: img/positions.png

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -218,6 +219,26 @@ class Address extends AbstractEntity
             'Remark'       => TimeframeService::DOMAIN_NAMESPACE,
             'Street'       => TimeframeService::DOMAIN_NAMESPACE,
             'Zipcode'      => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping' => [
+            'AddressType'  => ShippingService::DOMAIN_NAMESPACE,
+            'Area'         => ShippingService::DOMAIN_NAMESPACE,
+            'Buildingname' => ShippingService::DOMAIN_NAMESPACE,
+            'City'         => ShippingService::DOMAIN_NAMESPACE,
+            'CompanyName'  => ShippingService::DOMAIN_NAMESPACE,
+            'Countrycode'  => ShippingService::DOMAIN_NAMESPACE,
+            'Department'   => ShippingService::DOMAIN_NAMESPACE,
+            'Doorcode'     => ShippingService::DOMAIN_NAMESPACE,
+            'FirstName'    => ShippingService::DOMAIN_NAMESPACE,
+            'Floor'        => ShippingService::DOMAIN_NAMESPACE,
+            'HouseNr'      => ShippingService::DOMAIN_NAMESPACE,
+            'HouseNrExt'   => ShippingService::DOMAIN_NAMESPACE,
+            'StreetHouseNrExt'   => ShippingService::DOMAIN_NAMESPACE,
+            'Name'         => ShippingService::DOMAIN_NAMESPACE,
+            'Region'       => ShippingService::DOMAIN_NAMESPACE,
+            'Remark'       => ShippingService::DOMAIN_NAMESPACE,
+            'Street'       => ShippingService::DOMAIN_NAMESPACE,
+            'Zipcode'      => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Amount.php
+++ b/src/Entity/Amount.php
@@ -33,6 +33,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -131,6 +132,16 @@ class Amount extends AbstractEntity
             'Reference'         => TimeframeService::DOMAIN_NAMESPACE,
             'TransactionNumber' => TimeframeService::DOMAIN_NAMESPACE,
             'Value'             => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'  => [
+            'AccountName'       => ShippingService::DOMAIN_NAMESPACE,
+            'AmountType'        => ShippingService::DOMAIN_NAMESPACE,
+            'BIC'               => ShippingService::DOMAIN_NAMESPACE,
+            'Currency'          => ShippingService::DOMAIN_NAMESPACE,
+            'IBAN'              => ShippingService::DOMAIN_NAMESPACE,
+            'Reference'         => ShippingService::DOMAIN_NAMESPACE,
+            'TransactionNumber' => ShippingService::DOMAIN_NAMESPACE,
+            'Value'             => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Barcode.php
+++ b/src/Entity/Barcode.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -85,6 +86,11 @@ class Barcode extends AbstractEntity
             'Type'  => TimeframeService::DOMAIN_NAMESPACE,
             'Range' => TimeframeService::DOMAIN_NAMESPACE,
             'Serie' => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'Type'  => ShippingService::DOMAIN_NAMESPACE,
+            'Range' => ShippingService::DOMAIN_NAMESPACE,
+            'Serie' => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Contact.php
+++ b/src/Entity/Contact.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -94,6 +95,12 @@ class Contact extends AbstractEntity
             'Email'       => TimeframeService::DOMAIN_NAMESPACE,
             'SMSNr'       => TimeframeService::DOMAIN_NAMESPACE,
             'TelNr'       => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'ContactType' => ShippingService::DOMAIN_NAMESPACE,
+            'Email'       => ShippingService::DOMAIN_NAMESPACE,
+            'SMSNr'       => ShippingService::DOMAIN_NAMESPACE,
+            'TelNr'       => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -121,6 +122,15 @@ class Content extends AbstractEntity
             'Value'           => TimeframeService::DOMAIN_NAMESPACE,
             'Weight'          => TimeframeService::DOMAIN_NAMESPACE,
             'Content'         => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'CountryOfOrigin' => ShippingService::DOMAIN_NAMESPACE,
+            'Description'     => ShippingService::DOMAIN_NAMESPACE,
+            'HSTariffNr'      => ShippingService::DOMAIN_NAMESPACE,
+            'Quantity'        => ShippingService::DOMAIN_NAMESPACE,
+            'Value'           => ShippingService::DOMAIN_NAMESPACE,
+            'Weight'          => ShippingService::DOMAIN_NAMESPACE,
+            'Content'         => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -121,6 +122,15 @@ class Customer extends AbstractEntity
             'Email'              => TimeframeService::DOMAIN_NAMESPACE,
             'Name'               => TimeframeService::DOMAIN_NAMESPACE,
         ],
+        'Shipping'       => [
+            'Address'            => ShippingService::DOMAIN_NAMESPACE,
+            'CollectionLocation' => ShippingService::DOMAIN_NAMESPACE,
+            'ContactPerson'      => ShippingService::DOMAIN_NAMESPACE,
+            'CustomerCode'       => ShippingService::DOMAIN_NAMESPACE,
+            'CustomerNumber'     => ShippingService::DOMAIN_NAMESPACE,
+            'Email'              => ShippingService::DOMAIN_NAMESPACE,
+            'Name'               => ShippingService::DOMAIN_NAMESPACE,
+        ]
     ];
     // @codingStandardsIgnoreStart
     /** @var Address|null $Address */

--- a/src/Entity/Customs.php
+++ b/src/Entity/Customs.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -148,6 +149,18 @@ class Customs extends AbstractEntity
             'License'                => TimeframeService::DOMAIN_NAMESPACE,
             'LicenseNr'              => TimeframeService::DOMAIN_NAMESPACE,
             'ShipmentType'           => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'       => [
+            'Certificate'            => ShippingService::DOMAIN_NAMESPACE,
+            'CertificateNr'          => ShippingService::DOMAIN_NAMESPACE,
+            'Content'                => ShippingService::DOMAIN_NAMESPACE,
+            'Currency'               => ShippingService::DOMAIN_NAMESPACE,
+            'HandleAsNonDeliverable' => ShippingService::DOMAIN_NAMESPACE,
+            'Invoice'                => ShippingService::DOMAIN_NAMESPACE,
+            'InvoiceNr'              => ShippingService::DOMAIN_NAMESPACE,
+            'License'                => ShippingService::DOMAIN_NAMESPACE,
+            'LicenseNr'              => ShippingService::DOMAIN_NAMESPACE,
+            'ShipmentType'           => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Dimension.php
+++ b/src/Entity/Dimension.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -103,6 +104,13 @@ class Dimension extends AbstractEntity
             'Volume' => TimeframeService::DOMAIN_NAMESPACE,
             'Weight' => TimeframeService::DOMAIN_NAMESPACE,
             'Width'  => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'Height' => ShippingService::DOMAIN_NAMESPACE,
+            'Length' => ShippingService::DOMAIN_NAMESPACE,
+            'Volume' => ShippingService::DOMAIN_NAMESPACE,
+            'Weight' => ShippingService::DOMAIN_NAMESPACE,
+            'Width'  => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -94,6 +95,12 @@ class Group extends AbstractEntity
             'GroupSequence' => TimeframeService::DOMAIN_NAMESPACE,
             'GroupType'     => TimeframeService::DOMAIN_NAMESPACE,
             'MainBarcode'   => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'       => [
+            'GroupCount'    => ShippingService::DOMAIN_NAMESPACE,
+            'GroupSequence' => ShippingService::DOMAIN_NAMESPACE,
+            'GroupType'     => ShippingService::DOMAIN_NAMESPACE,
+            'MainBarcode'   => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Label.php
+++ b/src/Entity/Label.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -88,6 +89,11 @@ class Label extends AbstractEntity
             'Content'     => TimeframeService::DOMAIN_NAMESPACE,
             'ContentType' => TimeframeService::DOMAIN_NAMESPACE,
             'Labeltype'   => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'Content'     => ShippingService::DOMAIN_NAMESPACE,
+            'ContentType' => ShippingService::DOMAIN_NAMESPACE,
+            'Labeltype'   => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Message/LabellingMessage.php
+++ b/src/Entity/Message/LabellingMessage.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -86,6 +87,11 @@ class LabellingMessage extends Message
             'MessageTimeStamp' => TimeframeService::DOMAIN_NAMESPACE,
             'Printertype'      => TimeframeService::DOMAIN_NAMESPACE,
         ],
+        'Shipping'       => [
+            'MessageID'        => ShippingService::DOMAIN_NAMESPACE,
+            'MessageTimeStamp' => ShippingService::DOMAIN_NAMESPACE,
+            'Printertype'      => ShippingService::DOMAIN_NAMESPACE,
+        ] ,
     ];
     /**
      * @var string|null $Printertype

--- a/src/Entity/Message/Message.php
+++ b/src/Entity/Message/Message.php
@@ -33,6 +33,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -79,6 +80,10 @@ class Message extends AbstractEntity
         'Timeframe'      => [
             'MessageID'        => TimeframeService::DOMAIN_NAMESPACE,
             'MessageTimeStamp' => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'MessageID'        => ShippingService::DOMAIN_NAMESPACE,
+            'MessageTimeStamp' => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/ProductOption.php
+++ b/src/Entity/ProductOption.php
@@ -31,6 +31,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -76,6 +77,10 @@ class ProductOption extends AbstractEntity
         'Timeframe'  => [
             'Characteristic' => TimeframeService::DOMAIN_NAMESPACE,
             'Option'         => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'  => [
+            'Characteristic' => ShippingService::DOMAIN_NAMESPACE,
+            'Option'         => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Request/GenerateShipping.php
+++ b/src/Entity/Request/GenerateShipping.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2020 KeenDelivery, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @author    Jan-Wilco peters <info@keendelivery.com>
+ * @copyright 2017-2020 KeenDelivery, LLC
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace ThirtyBees\PostNL\Entity\Request;
+
+use ThirtyBees\PostNL\Entity\AbstractEntity;
+use ThirtyBees\PostNL\Entity\Barcode;
+use ThirtyBees\PostNL\Entity\Customer;
+use ThirtyBees\PostNL\Entity\Message\LabellingMessage;
+use ThirtyBees\PostNL\Entity\Message\Message;
+use ThirtyBees\PostNL\Entity\Shipment;
+use ThirtyBees\PostNL\Service\BarcodeService;
+use ThirtyBees\PostNL\Service\ConfirmingService;
+use ThirtyBees\PostNL\Service\DeliveryDateService;
+use ThirtyBees\PostNL\Service\LabellingService;
+use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
+use ThirtyBees\PostNL\Service\ShippingStatusService;
+use ThirtyBees\PostNL\Service\TimeframeService;
+
+/**
+ * Class GenerateShipping
+ *
+ * @package ThirtyBees\PostNL\Entity
+ *
+ * @method Customer|null    getCustomer()
+ * @method Message|null     getMessage()
+ * @method Shipment[]|null  getShipments()
+ *
+ * @method GenerateShipping setCustomer(Customer|null $customer = null)
+ * @method GenerateShipping setMessage(Message|null $message = null)
+ * @method GenerateShipping setShipments(Shipment[]|null $shipments = null)
+ */
+class GenerateShipping extends AbstractEntity
+{
+    /**
+     * @var array $defaultProperties
+     */
+    public static $defaultProperties = [
+        'Shipping'      => [
+            'Customer'  => ShippingService::DOMAIN_NAMESPACE,
+            'Message'   => ShippingService::DOMAIN_NAMESPACE,
+            'Shipments' => ShippingService::DOMAIN_NAMESPACE,
+        ],
+    ];
+
+    // @codingStandardsIgnoreStart
+    /** @var Customer|null $Customer */
+    protected $Customer;
+    /** @var LabellingMessage|null $Message */
+    protected $Message;
+    /** @var Shipment[]|null $Shipments */
+    protected $Shipments;
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * GenerateShipping constructor.
+     *
+     * @param Shipment[]|null       $shipments
+     * @param LabellingMessage|null $message
+     * @param Customer|null         $customer
+     */
+    public function __construct(array $shipments = null, LabellingMessage $message = null, Customer $customer = null)
+    {
+        parent::__construct();
+
+        $this->setShipments($shipments);
+        $this->setMessage($message ?: new LabellingMessage());
+        $this->setCustomer($customer);
+    }
+
+    /**
+     * Return a serializable array for `json_encode`
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $json = [];
+        if (!$this->currentService || !in_array($this->currentService, array_keys(static::$defaultProperties))) {
+            return $json;
+        }
+
+        foreach (array_keys(static::$defaultProperties[$this->currentService]) as $propertyName) {
+            if (isset($this->{$propertyName})) {
+                if ($propertyName === 'Shipments' && count($this->{$propertyName}) >= 1) {
+//                    $json[$propertyName] = $this->{$propertyName}[0];
+                    $properties = [];
+                    foreach ($this->{$propertyName} as $property) {
+                        $properties[] = $property;
+                    }
+                    $json[$propertyName] = $properties;
+                } else {
+                    $json[$propertyName] = $this->{$propertyName};
+                }
+            }
+        }
+
+        return $json;
+    }
+}

--- a/src/Entity/Request/GenerateShipping.php
+++ b/src/Entity/Request/GenerateShipping.php
@@ -107,7 +107,6 @@ class GenerateShipping extends AbstractEntity
         foreach (array_keys(static::$defaultProperties[$this->currentService]) as $propertyName) {
             if (isset($this->{$propertyName})) {
                 if ($propertyName === 'Shipments' && count($this->{$propertyName}) >= 1) {
-//                    $json[$propertyName] = $this->{$propertyName}[0];
                     $properties = [];
                     foreach ($this->{$propertyName} as $property) {
                         $properties[] = $property;

--- a/src/Entity/Response/GenerateShippingResponse.php
+++ b/src/Entity/Response/GenerateShippingResponse.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2020 keenDelivery, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @author    Jan-Wilco peters <info@keendelivery.com>
+ * @copyright 2017-2020 KeenDelivery, LLC
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace ThirtyBees\PostNL\Entity\Response;
+
+use ThirtyBees\PostNL\Entity\AbstractEntity;
+use ThirtyBees\PostNL\Service\BarcodeService;
+use ThirtyBees\PostNL\Service\ConfirmingService;
+use ThirtyBees\PostNL\Service\DeliveryDateService;
+use ThirtyBees\PostNL\Service\LabellingService;
+use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
+use ThirtyBees\PostNL\Service\ShippingStatusService;
+use ThirtyBees\PostNL\Service\TimeframeService;
+
+/**
+ * Class GenerateLabelResponse
+ *
+ * @package ThirtyBees\PostNL\Entity
+ *
+ * @method MergedLabel[]|null      getMergedLabels()
+ * @method ResponseShipment[]|null getResponseShipments()
+ *
+ * @method GenerateShippingResponse setMergedLabels(MergedLabel[]|null $mergedLabels = null)
+ * @method GenerateShippingResponse setResponseShipments(ResponseShipment[]|null $responseShipment = null)
+ */
+class GenerateShippingResponse extends AbstractEntity
+{
+    /**
+     * @var array|null $defaultProperties
+     */
+    public static $defaultProperties = [
+        'Barcode'        => [
+            'MergedLabels'      => BarcodeService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => BarcodeService::DOMAIN_NAMESPACE,
+        ],
+        'Confirming'     => [
+            'MergedLabels'      => ConfirmingService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => ConfirmingService::DOMAIN_NAMESPACE,
+        ],
+        'Labelling'      => [
+            'MergedLabels'      => LabellingService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => LabellingService::DOMAIN_NAMESPACE,
+        ],
+        'ShippingStatus' => [
+            'MergedLabels'      => ShippingStatusService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => ShippingStatusService::DOMAIN_NAMESPACE,
+        ],
+        'DeliveryDate'   => [
+            'MergedLabels'      => DeliveryDateService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => DeliveryDateService::DOMAIN_NAMESPACE,
+        ],
+        'Location'       => [
+            'MergedLabels'      => LocationService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => LocationService::DOMAIN_NAMESPACE,
+        ],
+        'Timeframe'      => [
+            'MergedLabels'      => TimeframeService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'       => [
+            'MergedLabels'      => ShippingService::DOMAIN_NAMESPACE,
+            'ResponseShipments' => ShippingService::DOMAIN_NAMESPACE,
+        ],
+    ];
+    // @codingStandardsIgnoreStart
+    /** @var MergedLabel[]|null $MergedLabels */
+    protected $MergedLabels;
+    /** @var ResponseShipment[]|null $ResponseShipments */
+    protected $ResponseShipments;
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * GenerateShippingResponse constructor.
+     *
+     * @param MergedLabel[]|null      $mergedLabels
+     * @param ResponseShipment[]|null $responseShipments
+     */
+    public function __construct(array $mergedLabels = null, array $responseShipments = null)
+    {
+        parent::__construct();
+
+        $this->setMergedLabels($mergedLabels);
+        $this->setResponseShipments($responseShipments);
+    }
+}

--- a/src/Entity/Response/MergedLabel.php
+++ b/src/Entity/Response/MergedLabel.php
@@ -33,6 +33,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -78,6 +79,10 @@ class MergedLabel extends AbstractEntity
         'Timeframe'      => [
             'Barcodes' => TimeframeService::DOMAIN_NAMESPACE,
             'Labels'   => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'Barcodes' => ShippingService::DOMAIN_NAMESPACE,
+            'Labels'   => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Response/ResponseShipment.php
+++ b/src/Entity/Response/ResponseShipment.php
@@ -34,6 +34,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -124,6 +125,15 @@ class ResponseShipment extends AbstractEntity
             'Labels'              => TimeframeService::DOMAIN_NAMESPACE,
             'ProductCodeDelivery' => TimeframeService::DOMAIN_NAMESPACE,
             'Warnings'            => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'Barcode'             => ShippingService::DOMAIN_NAMESPACE,
+            'DownPartnerBarcode'  => ShippingService::DOMAIN_NAMESPACE,
+            'DownPartnerID'       => ShippingService::DOMAIN_NAMESPACE,
+            'DownPartnerLocation' => ShippingService::DOMAIN_NAMESPACE,
+            'Labels'              => ShippingService::DOMAIN_NAMESPACE,
+            'ProductCodeDelivery' => ShippingService::DOMAIN_NAMESPACE,
+            'Warnings'            => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -32,6 +32,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 
@@ -397,6 +398,46 @@ class Shipment extends AbstractEntity
             'StatusCode'               => TimeframeService::DOMAIN_NAMESPACE,
             'DateFrom'                 => TimeframeService::DOMAIN_NAMESPACE,
             'DateTo'                   => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping'      => [
+            'Addresses'                => ShippingService::DOMAIN_NAMESPACE,
+            'Amounts'                  => ShippingService::DOMAIN_NAMESPACE,
+            'Barcode'                  => ShippingService::DOMAIN_NAMESPACE,
+            'CollectionTimeStampEnd'   => ShippingService::DOMAIN_NAMESPACE,
+            'CollectionTimeStampStart' => ShippingService::DOMAIN_NAMESPACE,
+            'Contacts'                 => ShippingService::DOMAIN_NAMESPACE,
+            'Content'                  => ShippingService::DOMAIN_NAMESPACE,
+            'CostCenter'               => ShippingService::DOMAIN_NAMESPACE,
+            'Customer'                 => ShippingService::DOMAIN_NAMESPACE,
+            'CustomerOrderNumber'      => ShippingService::DOMAIN_NAMESPACE,
+            'Customs'                  => ShippingService::DOMAIN_NAMESPACE,
+            'DeliveryAddress'          => ShippingService::DOMAIN_NAMESPACE,
+            'DeliveryTimestampStart'   => ShippingService::DOMAIN_NAMESPACE,
+            'DeliveryTimestampEnd'     => ShippingService::DOMAIN_NAMESPACE,
+            'DeliveryDate'             => ShippingService::DOMAIN_NAMESPACE,
+            'Dimension'                => ShippingService::DOMAIN_NAMESPACE,
+            'DownPartnerBarcode'       => ShippingService::DOMAIN_NAMESPACE,
+            'DownPartnerID'            => ShippingService::DOMAIN_NAMESPACE,
+            'DownPartnerLocation'      => ShippingService::DOMAIN_NAMESPACE,
+            'Events'                   => ShippingService::DOMAIN_NAMESPACE,
+            'Groups'                   => ShippingService::DOMAIN_NAMESPACE,
+            'IDExpiration'             => ShippingService::DOMAIN_NAMESPACE,
+            'IDNumber'                 => ShippingService::DOMAIN_NAMESPACE,
+            'IDType'                   => ShippingService::DOMAIN_NAMESPACE,
+            'OldStatuses'              => ShippingService::DOMAIN_NAMESPACE,
+            'PhaseCode'                => ShippingService::DOMAIN_NAMESPACE,
+            'ProductCodeCollect'       => ShippingService::DOMAIN_NAMESPACE,
+            'ProductCodeDelivery'      => ShippingService::DOMAIN_NAMESPACE,
+            'ProductOptions'           => ShippingService::DOMAIN_NAMESPACE,
+            'ReceiverDateOfBirth'      => ShippingService::DOMAIN_NAMESPACE,
+            'Reference'                => ShippingService::DOMAIN_NAMESPACE,
+            'ReferenceCollect'         => ShippingService::DOMAIN_NAMESPACE,
+            'Remark'                   => ShippingService::DOMAIN_NAMESPACE,
+            'ReturnBarcode'            => ShippingService::DOMAIN_NAMESPACE,
+            'ReturnReference'          => ShippingService::DOMAIN_NAMESPACE,
+            'StatusCode'               => ShippingService::DOMAIN_NAMESPACE,
+            'DateFrom'                 => ShippingService::DOMAIN_NAMESPACE,
+            'DateTo'                   => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart

--- a/src/PostNL.php
+++ b/src/PostNL.php
@@ -41,6 +41,7 @@ use ThirtyBees\PostNL\Entity\Request\Confirming;
 use ThirtyBees\PostNL\Entity\Request\CurrentStatus;
 use ThirtyBees\PostNL\Entity\Request\GenerateBarcode;
 use ThirtyBees\PostNL\Entity\Request\GenerateLabel;
+use ThirtyBees\PostNL\Entity\Request\GenerateShipping;
 use ThirtyBees\PostNL\Entity\Request\GetDeliveryDate;
 use ThirtyBees\PostNL\Entity\Request\GetLocation;
 use ThirtyBees\PostNL\Entity\Request\GetLocationsInArea;
@@ -73,6 +74,7 @@ use ThirtyBees\PostNL\Service\ConfirmingService;
 use ThirtyBees\PostNL\Service\DeliveryDateService;
 use ThirtyBees\PostNL\Service\LabellingService;
 use ThirtyBees\PostNL\Service\LocationService;
+use ThirtyBees\PostNL\Service\ShippingService;
 use ThirtyBees\PostNL\Service\ShippingStatusService;
 use ThirtyBees\PostNL\Service\TimeframeService;
 use ThirtyBees\PostNL\Util\RFPdi;
@@ -206,6 +208,9 @@ class PostNL implements LoggerAwareInterface
 
     /** @var LocationService $locationService */
     protected $locationService;
+
+    /** @var ShippingService $shippingService */
+    protected  $shippingService;
 
     /**
      * PostNL constructor.
@@ -612,6 +617,53 @@ class PostNL implements LoggerAwareInterface
     public function setLocationService(LocationService $service)
     {
         $this->locationService = $service;
+    }
+
+    /**
+     * Shipping service
+     *
+     * Automatically load the shipping service
+     *
+     * @return mixed
+     */
+    public function getShippingService()
+    {
+        if (!$this->shippingService) {
+            $this->setShippingService(new ShippingService($this));
+        }
+
+        return $this->shippingService;
+    }
+
+    /**
+     * Set the shipping service
+     *
+     * @param ShippingService $service
+     */
+    public function setShippingService(ShippingService $service)
+    {
+        $this->shippingService = $service;
+    }
+
+    /**
+     * @param Shipment $shipment
+     * @param string $printertype
+     * @param bool $confirm
+     *
+     * @return Entity\Response\GenerateShippingResponse
+     */
+    public function generateShipping(
+        Shipment $shipment,
+        $printertype = 'GraphicFile|PDF',
+        $confirm = true
+    ) {
+        return $this->getShippingService()->generateShipping(
+            new GenerateShipping(
+                [$shipment],
+                new LabellingMessage($printertype),
+                $this->customer
+            ),
+            $confirm);
     }
 
     /**

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -198,6 +198,18 @@ abstract class AbstractService
             throw new CifException($exceptionData);
         }
 
+        if (!empty($body['Errors'])) {
+            $exceptionData = [];
+            foreach ($body['Errors'] as $error) {
+                $exceptionData[] = [
+                    'description' => isset($error['Description']) ? (string) $error['Description'] : null,
+                    'message'     => isset($error['Error']) ? (string) $error['Error'] : null,
+                    'code'        => isset($error['Code']) ? (int) $error['Code'] : 0,
+                ];
+            }
+            throw new CifException($exceptionData);
+        }
+
         return true;
     }
 

--- a/src/Service/ShippingService.php
+++ b/src/Service/ShippingService.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2020 KeenDelivery, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @author    Jan-Wilco peters <info@keendelivery.com>
+ * @copyright 2017-2020 KeenDelivery, LLC
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace ThirtyBees\PostNL\Service;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use ThirtyBees\PostNL\Entity\AbstractEntity;
+use ThirtyBees\PostNL\Entity\Request\GenerateShipping;
+use ThirtyBees\PostNL\Entity\Response\GenerateShippingResponse;
+use ThirtyBees\PostNL\Exception\ApiException;
+use ThirtyBees\PostNL\Exception\CifDownException;
+use ThirtyBees\PostNL\Exception\CifException;
+use ThirtyBees\PostNL\Exception\ResponseException;
+
+/**
+ * Class ShippingService
+ *
+ * @package ThirtyBees\PostNL\Service
+ *
+ * @method GenerateShippingResponse   generateShipping(GenerateShipping $generateShipping, bool $confirm)
+ * @method Request                    buildGenerateShippingRequest(GenerateShipping $generateShipping, bool $confirm)
+ * @method GenerateShippingResponse   processGenerateShippingResponse(mixed $response)
+ */
+class ShippingService extends AbstractService
+{
+    // API Version
+    const VERSION = '1';
+
+    // Endpoints
+    const LIVE_ENDPOINT = 'https://api.postnl.nl/v1/shipment';
+    const SANDBOX_ENDPOINT = 'https://api-sandbox.postnl.nl/v1/shipment';
+
+    const DOMAIN_NAMESPACE = 'http://postnl.nl/';
+
+    /**
+     * Generate a single Shipping vai REST
+     *
+     * @param GenerateShipping $generateShipping
+     * @param bool $confirm
+     *
+     * @return GenerateShippingResponse|null
+     *
+     * @throws ApiException
+     * @throws CifDownException
+     * @throws CifException
+     * @throws ResponseException
+     */
+    public function generateShippingREST(GenerateShipping $generateShipping, $confirm = true): ?GenerateShippingResponse
+    {
+        $item = $this->retrieveCachedItem($generateShipping->getId());
+        $response = null;
+
+        if ($item instanceof CachedItemInterface) {
+            $response = $item->get();
+            try {
+                $response = \GuzzleHttp\Psr7\parse_response($response);
+            }catch(\InvalidArgumentException $e) {
+            }
+        }
+        if (!$response instanceof Response) {
+            $response = $this->postnl->getHttpClient()->doRequest($this->buildGenerateShippingRequestREST($generateShipping, $confirm));
+
+            static::validateRESTResponse($response);
+        }
+
+        $object = $this->processGenerateShippingResponseREST($response);
+        if ($object instanceof GenerateShippingResponse) {
+            if ($item instanceof CachedItemInterface
+                && $response instanceof Response
+                && $response->getStatusCode() === 200
+            ) {
+                $item->set(\GuzzleHttp\Psr7\str($response));
+                $this->cacheItem($item);
+            }
+
+            return $object;
+        }
+
+        if ($response->getStatusCode() === 200) {
+            throw new ResponseException('Invalid API response', null, null, $response);
+        }
+
+        throw new ApiException('Unable to ship order');
+    }
+
+    public function buildGenerateShippingRequestREST(GenerateShipping $generateShipping, $confirm = true): Request
+    {
+        $apiKey = $this->postnl->getRestApiKey();
+        $this->setService($generateShipping);
+
+        return new Request(
+            'POST',
+            ($this->postnl->getSandbox() ? static::SANDBOX_ENDPOINT : static::LIVE_ENDPOINT).'?'.\GuzzleHttp\Psr7\build_query([
+                'confirm' => $confirm
+            ]),
+            [
+                'apikey' => $apiKey,
+                'Accept' => 'application/json',
+                'Content-type' => 'application/json;charset=UTF-8',
+            ],
+            json_encode($generateShipping, JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    /**
+     * Process the GenerateShipping REST Response
+     *
+     * @param Response $response
+     *
+     * @return GenerateShippingResponse|null
+     * @throws ResponseException
+     */
+    public function processGenerateShippingResponseREST($response): ?GenerateShippingResponse
+    {
+        $body = json_decode(static::getResponseText($response), true);
+        if (isset($body['ResponseShipments'])) {
+            /** @var GenerateShippingResponse $object */
+            $object = AbstractEntity::JsonDeserialize(['GenerateShippingResponse' => $body]);
+            $this->setService($object);
+
+            return $object;
+        }
+
+        return null;
+    }
+}

--- a/tests/Service/ShippingServiceRestTest.php
+++ b/tests/Service/ShippingServiceRestTest.php
@@ -326,4 +326,348 @@ class ShippingServiceRestTest extends \PHPUnit_Framework_TestCase
                 ->setProductCodeDelivery('3085')
         );
     }
+
+    /**
+     * @testdox can generate shippings with multiple A4-merged labels
+     *
+     * @throws \setasign\Fpdi\PdfReader\PdfReaderException
+     * @throws \Exception
+     */
+    public function testMergeMultipleA4LabelsRest()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611210',
+                        'Errors' => [],
+                        'Warnings' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611211',
+                        'Errors' => [],
+                        'Warnings' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $mockClient = new MockClient();
+        $mockClient->setHandler($handler);
+        $this->postnl->setHttpClient($mockClient);
+
+        $shipping = $this->postnl->generateShippings([
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085'),
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085'),
+        ],
+            'GraphicFile|PDF',
+            true,
+            true,
+            Label::FORMAT_A4,
+            [
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+            ]
+        );
+
+        $this->assertTrue(is_string($shipping));
+    }
+
+    /**
+     * @testdox can generate shippings with multiple A6-merged labels
+     *
+     * @throws \setasign\Fpdi\PdfReader\PdfReaderException
+     * @throws \Exception
+     */
+    public function testMergeMultipleA6LabelsRest()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611210',
+                        'Errors' => [],
+                        'Warnings' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611211',
+                        'Errors' => [],
+                        'Warnings' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $mockClient = new MockClient();
+        $mockClient->setHandler($handler);
+        $this->postnl->setHttpClient($mockClient);
+
+        $label = $this->postnl->generateShippings([
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085'),
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085'),
+        ],
+            'GraphicFile|PDF',
+            true,
+            true,
+            Label::FORMAT_A6,
+            [
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+            ]
+        );
+
+        $this->assertTrue(is_string($label));
+    }
+
+    /**
+     * @testdox can generate with multiple shippings
+     *
+     * @throws \setasign\Fpdi\PdfReader\PdfReaderException
+     * @throws \Exception
+     */
+    public function testGenerateMultipleShippingsRest()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611210',
+                        'Errors' => [],
+                        'Warnings' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611211',
+                        'Errors' => [],
+                        'Warnings' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $mockClient = new MockClient();
+        $mockClient->setHandler($handler);
+        $this->postnl->setHttpClient($mockClient);
+
+        $shippings = $this->postnl->generateShippings([
+                (new Shipment())
+                    ->setAddresses([
+                        Address::create([
+                            'AddressType' => '01',
+                            'City'        => 'Utrecht',
+                            'Countrycode' => 'NL',
+                            'FirstName'   => 'Peter',
+                            'HouseNr'     => '9',
+                            'HouseNrExt'  => 'a bis',
+                            'Name'        => 'de Ruijter',
+                            'Street'      => 'Bilderdijkstraat',
+                            'Zipcode'     => '3521VA',
+                        ]),
+                        Address::create([
+                            'AddressType' => '02',
+                            'City'        => 'Hoofddorp',
+                            'CompanyName' => 'PostNL',
+                            'Countrycode' => 'NL',
+                            'HouseNr'     => '42',
+                            'Street'      => 'Siriusdreef',
+                            'Zipcode'     => '2132WT',
+                        ]),
+                    ])
+                    ->setDeliveryAddress('01')
+                    ->setDimension(new Dimension('2000'))
+                    ->setProductCodeDelivery('3085'),
+                (new Shipment())
+                    ->setAddresses([
+                        Address::create([
+                            'AddressType' => '01',
+                            'City'        => 'Utrecht',
+                            'Countrycode' => 'NL',
+                            'FirstName'   => 'Peter',
+                            'HouseNr'     => '9',
+                            'HouseNrExt'  => 'a bis',
+                            'Name'        => 'de Ruijter',
+                            'Street'      => 'Bilderdijkstraat',
+                            'Zipcode'     => '3521VA',
+                        ]),
+                        Address::create([
+                            'AddressType' => '02',
+                            'City'        => 'Hoofddorp',
+                            'CompanyName' => 'PostNL',
+                            'Countrycode' => 'NL',
+                            'HouseNr'     => '42',
+                            'Street'      => 'Siriusdreef',
+                            'Zipcode'     => '2132WT',
+                        ]),
+                    ])
+                    ->setDeliveryAddress('01')
+                    ->setDimension(new Dimension('2000'))
+                    ->setProductCodeDelivery('3085'),
+            ]
+        );
+
+        $this->assertInstanceOf('\\ThirtyBees\\PostNL\\Entity\\Response\\GenerateShippingResponse', $shippings);
+    }
 }

--- a/tests/Service/ShippingServiceRestTest.php
+++ b/tests/Service/ShippingServiceRestTest.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2020 KeenDelivery, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @author    Jan-Wilco Peters <info@keendelivery.com>
+ * @copyright 2017-2020 KeenDelivery, LLC
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace ThirtyBees\PostNL\Tests\Service;
+
+use Cache\Adapter\Void\VoidCachePool;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\LoggerInterface;
+use ThirtyBees\PostNL\Entity\Address;
+use ThirtyBees\PostNL\Entity\Contact;
+use ThirtyBees\PostNL\Entity\Customer;
+use ThirtyBees\PostNL\Entity\Dimension;
+use ThirtyBees\PostNL\Entity\Label;
+use ThirtyBees\PostNL\Entity\Message\LabellingMessage;
+use ThirtyBees\PostNL\Entity\Request\GenerateShipping;
+use ThirtyBees\PostNL\Entity\Shipment;
+use ThirtyBees\PostNL\Entity\SOAP\UsernameToken;
+use ThirtyBees\PostNL\HttpClient\MockClient;
+use ThirtyBees\PostNL\PostNL;
+use ThirtyBees\PostNL\Service\ShippingService;
+
+/**
+ * Class ShippingServiceRestTest
+ *
+ * @package ThirtyBees\PostNL\Tests\Service
+ *
+ * @testdox The ShippingService (REST)
+ */
+class ShippingServiceRestTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var PostNL $postnl */
+    protected $postnl;
+    /** @var ShippingService $service */
+    protected $service;
+    /** @var $lastRequest */
+    protected $lastRequest;
+
+    /** @var string $base64LabelContent */
+    private static $base64LabelContent = 'JVBERi0xLjIgDQoxIDAgb2JqDQo8PA0KL1R5cGUgL0NhdGFsb2cNCi9QYWdlcyAzIDAgUg0KL1BhZ2VNb2RlIC9Vc2VOb25lDQovUGFnZUxheW91dCAvU2luZ2xlUGFnZQ0KPj4NCmVuZG9iag0KMiAwIG9iag0KPDwNCi9Qcm9kdWNlciAoUGRmQ3JlYXRvciB2ZXJzaW9uIDEuMCkNCi9BdXRob3IgKCkNCi9DcmVhdGlvbkRhdGUgKEQ6MjAxODAzMDYwMzE5NTkpDQovQ3JlYXRvciAoKQ0KL0tleXdvcmRzICgpDQovU3ViamVjdCAoKQ0KL1RpdGxlICgpDQovTW9kRGF0ZSAoRDoyMDE4MDMwNjAzMTk1OSkNCj4+DQplbmRvYmoNCjMgMCBvYmoNCjw8DQovVHlwZSAvUGFnZXMNCi9LaWRzIFs0IDAgUiBdDQovQ291bnQgMQ0KPj4NCmVuZG9iag0KNCAwIG9iag0KPDwNCi9UeXBlIC9QYWdlDQovUGFyZW50IDMgMCBSDQovTWVkaWFCb3ggWzAgMCA0MjUgMjkyIF0NCi9SZXNvdXJjZXMgPDwNCi9Gb250IDw8DQovRjAgNiAwIFINCi9GMSA4IDAgUg0KPj4NCi9YT2JqZWN0IDw8DQovMCA3IDAgUg0KPj4NCi9Qcm9jU2V0IFsvUERGIC9UZXh0IC9JbWFnZUMgXQ0KPj4NCi9Db250ZW50cyA1IDAgUg0KPj4NCmVuZG9iag0KNSAwIG9iag0KPDwNCi9MZW5ndGggNDA3DQovRmlsdGVyIFsvRmxhdGVEZWNvZGUgXQ0KPj4NCnN0cmVhbQ0KeF6dU8tOwzAQvPsr9gg9uN514ibcCn1wqHg1lAPiUJoUUtoGnCAkvp6N07QFJBqhSNEktmfWM7vtgYJQdnyI5qLEqEqkoHzskziNBEql+GvvXf3RgeHdnuSjK3GEcJYtl9kxRAvRj3YEiJJ4x+hvpgBI04apOxnWLPcPCmKhvRAo8GElPPQcWlbIGEZu1aGq6JuhQPgQebM78EHq1MoDO13PtleoxEl1gCh04ryXUSnON8eAUblaoa24aiyOLI61fy097vUnZ6TQIBKqVu1BGUrwLZPwgJ2uZLaTXDBXl+PoYlSzvQkyvlSes8o30oRgAqk0kC99D2Yr0VbQy8T1zr5Dci6JWq07/0zWcWJPfjVCExqfm6UqOsuLXdHbbmzC4dWljFObvuexTZI5ePSverYmEmq6i+A8y+ZxnNnX/XB+TEyThud8gTDYNPxVUiQW4gRu3lNG/xohx6jMhvE0XXIGcbp4yQs7nRYQwhQe03xXNgKy03uDjro8++eYlhoYasndyBFpX9OkC7eFTWbPRc38BUKk6VAKZW5kc3RyZWFtDQplbmRvYmoNCjYgMCBvYmoNCjw8DQovVHlwZSAvRm9udA0KL1N1YnR5cGUgL1R5cGUxDQovRmlyc3RDaGFyIDMyDQovTGFzdENoYXIgMjU1DQovQmFzZUZvbnQgL0hlbHZldGljYQ0KL0VuY29kaW5nIDw8DQovVHlwZSAvRW5jb2RpbmcNCi9EaWZmZXJlbmNlcyBbMzIgL3NwYWNlIDE5NiAvQWRpZXJlc2lzIDIxNCAvT2RpZXJlc2lzIDIyMCAvVWRpZXJlc2lzIDIyOCAvYWRpZXJlc2lzIDI0NiAvb2RpZXJlc2lzIDI1MiAvdWRpZXJlc2lzIDIyMyAvZ2VybWFuZGJscyAxOTIgL0FncmF2ZSAxOTQgL0FjaXJjdW1mbGV4IDE5OCAvQUUgMTk5IC9DY2VkaWxsYSAyMDAgL0VncmF2ZSAyMDEgL0VhY3V0ZSAyMDIgL0VjaXJjdW1mbGV4IDIwMyAvRWRpZXJlc2lzIDIwNiAvSWNpcmN1bWZsZXggMjA3IC9JZGllcmVzaXMgMjEyIC9PY2lyY3VtZmxleCAxNDAgL09FIDIxNyAvVWdyYXZlIDIxOSAvVWNpcmN1bWZsZXggMTU5IC9ZZGllcmVzaXMgMjI0IC9hZ3JhdmUgMjI2IC9hY2lyY3VtZmxleCAyMzAgL2FlIDIzMSAvY2NlZGlsbGEgMjMyIC9lZ3JhdmUgMjMzIC9lYWN1dGUgMjM0IC9lY2lyY3VtZmxleCAyMzUgL2VkaWVyZXNpcyAyMzggL2ljaXJjdW1mbGV4IDIzOSAvaWRpZXJlc2lzIDI0NCAvb2NpcmN1bWZsZXggMTU2IC9vZSAyNDkgL3VncmF2ZSAyNTEgL3VjaXJjdW1mbGV4IDI1NSAveWRpZXJlc2lzIDE5NyAvQXJpbmcgMjE2IC9Pc2xhc2ggMTkzIC9BYWN1dGUgMjA1IC9JYWN1dGUgMjE4IC9VYWN1dGUgMjIxIC9ZYWN1dGUgMjI5IC9hcmluZyAyNDggL29zbGFzaCAyMjUgL2FhY3V0ZSAyMzcgL2lhY3V0ZSAyNTAgL3VhY3V0ZSAyNTMgL3lhY3V0ZSAyMTAgL09ncmF2ZSAyNDIgL29ncmF2ZSAyMDQgL0lncmF2ZSAyMzYgL2lncmF2ZSAxOTUgL0F0aWxkZSAyMTMgL090aWxkZSAyMjcgL2F0aWxkZSAyNDUgL290aWxkZSAyMjIgL1Rob3JuIDI1NCAvdGhvcm4gMjA5IC9OdGlsZGUgMjQxIC9udGlsZGUgMTM4IC9TY2Fyb24gMTU0IC9zY2Fyb24gMjQzIC9vYWN1dGUgMjExIC9PYWN1dGUgXQ0KPj4NCi9XaWR0aHMgWzI3OCAyNzggMzU1IDU1NiA1NTYgODg5IDY2NyAxOTEgMzMzIDMzMyAzODkgNTg0IDI3OCAzMzMgMjc4IDI3OCA1NTYgNTU2IDU1NiA1NTYgNTU2IDU1NiA1NTYgNTU2IDU1NiA1NTYgMjc4IDI3OCA1ODQgNTg0IDU4NCA1NTYgMTAxNSA2NjcgNjY3IDcyMiA3MjIgNjY3IDYxMSA3NzggNzIyIDI3OCA1MDAgNjY3IDU1NiA4MzMgNzIyIDc3OCA2NjcgNzc4IDcyMiA2NjcgNjExIDcyMiA2NjcgOTQ0IDY2NyA2NjcgNjExIDI3OCAyNzggMjc4IDQ2OSA1NTYgMzMzIDU1NiA1NTYgNTAwIDU1NiA1NTYgMjc4IDU1NiA1NTYgMjIyIDIyMiA1MDAgMjIyIDgzMyA1NTYgNTU2IDU1NiA1NTYgMzMzIDUwMCAyNzggNTU2IDUwMCA3MjIgNTAwIDUwMCA1MDAgMzM0IDI2MCAzMzQgNTg0IDAgNTU2IDAgMjIyIDU1NiAzMzMgMTAwMCA1NTYgNTU2IDMzMyAxMDAwIDY2NyAzMzMgMTAwMCAwIDYxMSAwIDAgMjIyIDIyMiAzMzMgMzMzIDM1MCA1NTYgMTAwMCAzMzMgMTAwMCA1MDAgMzMzIDk0NCAwIDUwMCA2NjcgMCA2NjcgNTU2IDU1NiA1NTYgNTU2IDY2NyA1NTYgMzMzIDczNyAzNzAgNTU2IDYxMSAwIDczNyA2MTEgNDAwIDU1NiAzMzMgMjIyIDMzMyA1NTYgNTAwIDMzMyAzMzMgMjc4IDM2NSA1NTYgNTAwIDgzNCA4MzQgNTAwIDY2NyA2NjcgNjY3IDY2NyA2NjcgNjY3IDEwMDAgNzIyIDY2NyA2NjcgNjY3IDY2NyAyNzggMjc4IDMzMyAzMzMgNzIyIDcyMiA3NzggNzc4IDc3OCA3NzggNzc4IDU4NCA3NzggNzIyIDcyMiA3MjIgNzIyIDY2NyA2NjcgNjExIDU1NiA1NTYgNTU2IDU1NiA1NTYgNTU2IDg4OSA1MDAgNTU2IDU1NiA1NTYgNTU2IDI3OCAyNzggMzMzIDMzMyA1NTYgNTU2IDU1NiA1NTYgNTU2IDU1NiA1NTYgNTg0IDYxMSA1NTYgNTU2IDU1NiA1NTYgNTAwIDU1NiA1MDAgXQ0KL05hbWUgL0YwDQo+Pg0KZW5kb2JqDQo3IDAgb2JqDQo8PA0KL0xlbmd0aCAxNDgNCi9GaWx0ZXIgWy9GbGF0ZURlY29kZSBdDQovVHlwZSAvWE9iamVjdA0KL1N1YnR5cGUgL0ltYWdlDQovQ29sb3JTcGFjZSBbL0luZGV4ZWQgL0RldmljZVJHQiAyMjMgPDAwMDAwMCAwMDAwMzMgMDAwMDY2IDAwMDA5OSAwMDAwY2MgMDAwMGZmIDAwMzMwMCAwMDMzMzMgMDAzMzY2IDAwMzM5OSAwMDMzY2MgMDAzM2ZmIDAwNjYwMCAwMDY2MzMgMDA2NjY2IDAwNjY5OSAwMDY2Y2MgMDA2NmZmIDAwOTkwMCAwMDk5MzMgMDA5OTY2IDAwOTk5OSAwMDk5Y2MgMDA5OWZmIDAwY2MwMCAwMGNjMzMgMDBjYzY2IDAwY2M5OSAwMGNjY2MgMDBjY2ZmIDAwZmYwMCAwMGZmMzMgMDBmZjY2IDAwZmY5OSAwMGZmY2MgMDBmZmZmIDMzMDAwMCAzMzAwMzMgMzMwMDY2IDMzMDA5OSAzMzAwY2MgMzMwMGZmIDMzMzMwMCAzMzMzMzMgMzMzMzY2IDMzMzM5OSAzMzMzY2MgMzMzM2ZmIDMzNjYwMCAzMzY2MzMgMzM2NjY2IDMzNjY5OSAzMzY2Y2MgMzM2NmZmIDMzOTkwMCAzMzk5MzMgMzM5OTY2IDMzOTk5OSAzMzk5Y2MgMzM5OWZmIDMzY2MwMCAzM2NjMzMgMzNjYzY2IDMzY2M5OSAzM2NjY2MgMzNjY2ZmIDMzZmYwMCAzM2ZmMzMgMzNmZjY2IDMzZmY5OSAzM2ZmY2MgMzNmZmZmIDY2MDAwMCA2NjAwMzMgNjYwMDY2IDY2MDA5OSA2NjAwY2MgNjYwMGZmIDY2MzMwMCA2NjMzMzMgNjYzMzY2IDY2MzM5OSA2NjMzY2MgNjYzM2ZmIDY2NjYwMCA2NjY2MzMgNjY2NjY2IDY2NjY5OSA2NjY2Y2MgNjY2NmZmIDY2OTkwMCA2Njk5MzMgNjY5OTY2IDY2OTk5OSA2Njk5Y2MgNjY5OWZmIDY2Y2MwMCA2NmNjMzMgNjZjYzY2IDY2Y2M5OSA2NmNjY2MgNjZjY2ZmIDY2ZmYwMCA2NmZmMzMgNjZmZjY2IDY2ZmY5OSA2NmZmY2MgNjZmZmZmIDk5MDAwMCA5OTAwMzMgOTkwMDY2IDk5MDA5OSA5OTAwY2MgOTkwMGZmIDk5MzMwMCA5OTMzMzMgOTkzMzY2IDk5MzM5OSA5OTMzY2MgOTkzM2ZmIDk5NjYwMCA5OTY2MzMgOTk2NjY2IDk5NjY5OSA5OTY2Y2MgOTk2NmZmIDk5OTkwMCA5OTk5MzMgOTk5OTY2IDk5OTk5OSA5OTk5Y2MgOTk5OWZmIDk5Y2MwMCA5OWNjMzMgOTljYzY2IDk5Y2M5OSA5OWNjY2MgOTljY2ZmIDk5ZmYwMCA5OWZmMzMgOTlmZjY2IDk5ZmY5OSA5OWZmY2MgOTlmZmZmIGNjMDAwMCBjYzAwMzMgY2MwMDY2IGNjMDA5OSBjYzAwY2MgY2MwMGZmIGNjMzMwMCBjYzMzMzMgY2MzMzY2IGNjMzM5OSBjYzMzY2MgY2MzM2ZmIGNjNjYwMCBjYzY2MzMgY2M2NjY2IGNjNjY5OSBjYzY2Y2MgY2M2NmZmIGNjOTkwMCBjYzk5MzMgY2M5OTY2IGNjOTk5OSBjYzk5Y2MgY2M5OWZmIGNjY2MwMCBjY2NjMzMgY2NjYzY2IGNjY2M5OSBjY2NjY2MgY2NjY2ZmIGNjZmYwMCBjY2ZmMzMgY2NmZjY2IGNjZmY5OSBjY2ZmY2MgY2NmZmZmIGZmMDAwMCBmZjAwMzMgZmYwMDY2IGZmMDA5OSBmZjAwY2MgZmYwMGZmIGZmMzMwMCBmZjMzMzMgZmYzMzY2IGZmMzM5OSBmZjMzY2MgZmYzM2ZmIGZmNjYwMCBmZjY2MzMgZmY2NjY2IGZmNjY5OSBmZjY2Y2MgZmY2NmZmIGZmOTkwMCBmZjk5MzMgZmY5OTY2IGZmOTk5OSBmZjk5Y2MgZmY5OWZmIGZmY2MwMCBmZmNjMzMgZmZjYzY2IGZmY2M5OSBmZmNjY2MgZmZjY2ZmIGZmZmYwMCBmZmZmMzMgZmZmZjY2IGZmZmY5OSBmZmZmY2MgZmZmZmZmIGMwYzBjMCA4MDgwODAgODAwMDAwIDAwODAwMCAwMDAwODAgODA4MDAwIDgwMDA4MCAwMDgwODAgPiBdDQovV2lkdGggMjIwOQ0KL0hlaWdodCAxDQovQml0c1BlckNvbXBvbmVudCA4DQovTmFtZSAvMA0KPj4NCnN0cmVhbQ0KeF7FVcENACEMcv8FXed+2kSCEPT0ZWoUSltsY3W0wPEMld28y4/V99p4cANXSYNU1hBloKIypErY1xQwUElxKaCOssxvEoYZQX2DqvoaqAww/bWcYHjUeVIh/CQpqQL7c18lfqUO0qFm5/YYFF3VIIDoto3bRuxDbFrtHoNo4IMqaK6mu2QiOf/KZL+y++oDD7hI3QplbmRzdHJlYW0NCmVuZG9iag0KOCAwIG9iag0KPDwNCi9UeXBlIC9Gb250DQovU3VidHlwZSAvVHlwZTENCi9GaXJzdENoYXIgMzINCi9MYXN0Q2hhciAyNTUNCi9CYXNlRm9udCAvSGVsdmV0aWNhLUJvbGQNCi9FbmNvZGluZyA8PA0KL1R5cGUgL0VuY29kaW5nDQovRGlmZmVyZW5jZXMgWzMyIC9zcGFjZSAxOTYgL0FkaWVyZXNpcyAyMTQgL09kaWVyZXNpcyAyMjAgL1VkaWVyZXNpcyAyMjggL2FkaWVyZXNpcyAyNDYgL29kaWVyZXNpcyAyNTIgL3VkaWVyZXNpcyAyMjMgL2dlcm1hbmRibHMgMTkyIC9BZ3JhdmUgMTk0IC9BY2lyY3VtZmxleCAxOTggL0FFIDE5OSAvQ2NlZGlsbGEgMjAwIC9FZ3JhdmUgMjAxIC9FYWN1dGUgMjAyIC9FY2lyY3VtZmxleCAyMDMgL0VkaWVyZXNpcyAyMDYgL0ljaXJjdW1mbGV4IDIwNyAvSWRpZXJlc2lzIDIxMiAvT2NpcmN1bWZsZXggMTQwIC9PRSAyMTcgL1VncmF2ZSAyMTkgL1VjaXJjdW1mbGV4IDE1OSAvWWRpZXJlc2lzIDIyNCAvYWdyYXZlIDIyNiAvYWNpcmN1bWZsZXggMjMwIC9hZSAyMzEgL2NjZWRpbGxhIDIzMiAvZWdyYXZlIDIzMyAvZWFjdXRlIDIzNCAvZWNpcmN1bWZsZXggMjM1IC9lZGllcmVzaXMgMjM4IC9pY2lyY3VtZmxleCAyMzkgL2lkaWVyZXNpcyAyNDQgL29jaXJjdW1mbGV4IDE1NiAvb2UgMjQ5IC91Z3JhdmUgMjUxIC91Y2lyY3VtZmxleCAyNTUgL3lkaWVyZXNpcyAxOTcgL0FyaW5nIDIxNiAvT3NsYXNoIDE5MyAvQWFjdXRlIDIwNSAvSWFjdXRlIDIxOCAvVWFjdXRlIDIyMSAvWWFjdXRlIDIyOSAvYXJpbmcgMjQ4IC9vc2xhc2ggMjI1IC9hYWN1dGUgMjM3IC9pYWN1dGUgMjUwIC91YWN1dGUgMjUzIC95YWN1dGUgMjEwIC9PZ3JhdmUgMjQyIC9vZ3JhdmUgMjA0IC9JZ3JhdmUgMjM2IC9pZ3JhdmUgMTk1IC9BdGlsZGUgMjEzIC9PdGlsZGUgMjI3IC9hdGlsZGUgMjQ1IC9vdGlsZGUgMjIyIC9UaG9ybiAyNTQgL3Rob3JuIDIwOSAvTnRpbGRlIDI0MSAvbnRpbGRlIDEzOCAvU2Nhcm9uIDE1NCAvc2Nhcm9uIDI0MyAvb2FjdXRlIDIxMSAvT2FjdXRlIF0NCj4+DQovV2lkdGhzIFsyNzggMzMzIDQ3NCA1NTYgNTU2IDg4OSA3MjIgMjM4IDMzMyAzMzMgMzg5IDU4NCAyNzggMzMzIDI3OCAyNzggNTU2IDU1NiA1NTYgNTU2IDU1NiA1NTYgNTU2IDU1NiA1NTYgNTU2IDMzMyAzMzMgNTg0IDU4NCA1ODQgNjExIDk3NSA3MjIgNzIyIDcyMiA3MjIgNjY3IDYxMSA3NzggNzIyIDI3OCA1NTYgNzIyIDYxMSA4MzMgNzIyIDc3OCA2NjcgNzc4IDcyMiA2NjcgNjExIDcyMiA2NjcgOTQ0IDY2NyA2NjcgNjExIDMzMyAyNzggMzMzIDU4NCA1NTYgMzMzIDU1NiA2MTEgNTU2IDYxMSA1NTYgMzMzIDYxMSA2MTEgMjc4IDI3OCA1NTYgMjc4IDg4OSA2MTEgNjExIDYxMSA2MTEgMzg5IDU1NiAzMzMgNjExIDU1NiA3NzggNTU2IDU1NiA1MDAgMzg5IDI4MCAzODkgNTg0IDAgNTU2IDAgMjc4IDU1NiA1MDAgMTAwMCA1NTYgNTU2IDMzMyAxMDAwIDY2NyAzMzMgMTAwMCAwIDYxMSAwIDAgMjc4IDI3OCA1MDAgNTAwIDM1MCA1NTYgMTAwMCAzMzMgMTAwMCA1NTYgMzMzIDk0NCAwIDUwMCA2NjcgMCA3MjIgNTU2IDYxMSA1NTYgNTU2IDY2NyA1NTYgMzMzIDczNyAzNzAgNTU2IDYxMSAwIDczNyA2MTEgNDAwIDU1NiAzMzMgMjc4IDMzMyA2MTEgNTU2IDI3OCAzMzMgMzMzIDM2NSA1NTYgNTAwIDgzNCA4MzQgNTAwIDcyMiA3MjIgNzIyIDcyMiA3MjIgNzIyIDEwMDAgNzIyIDY2NyA2NjcgNjY3IDY2NyAyNzggMjc4IDI3OCAyNzggNzIyIDcyMiA3NzggNzc4IDc3OCA3NzggNzc4IDU4NCA3NzggNzIyIDcyMiA3MjIgNzIyIDY2NyA2NjcgNjExIDU1NiA1NTYgNTU2IDU1NiA1NTYgNTU2IDg4OSA1NTYgNTU2IDU1NiA1NTYgNTU2IDI3OCAyNzggMjc4IDI3OCA2MTEgNjExIDYxMSA2MTEgNjExIDYxMSA2MTEgNTg0IDYxMSA2MTEgNjExIDYxMSA2MTEgNTU2IDYxMSA1NTYgXQ0KL05hbWUgL0YxDQo+Pg0KZW5kb2JqDQp4cmVmDQowIDkNCjAwMDAwMDAwMDAgNjU1MzUgZg0KMDAwMDAwMDAxMSAwMDAwMCBuDQowMDAwMDAwMTExIDAwMDAwIG4NCjAwMDAwMDAyOTggMDAwMDAgbg0KMDAwMDAwMDM2MyAwMDAwMCBuDQowMDAwMDAwNTczIDAwMDAwIG4NCjAwMDAwMDEwNjMgMDAwMDAgbg0KMDAwMDAwMjk5NiAwMDAwMCBuDQowMDAwMDA0OTI2IDAwMDAwIG4NCnRyYWlsZXINCjw8DQovU2l6ZSA5DQovUm9vdCAxIDAgUg0KL0luZm8gMiAwIFINCj4+DQpzdGFydHhyZWYNCjY4NjMNCiUlRU9GDQo=';
+
+    /**
+     * @before
+     * @throws \ThirtyBees\PostNL\Exception\InvalidArgumentException
+     */
+    public function setupPostNL()
+    {
+        $this->postnl = new PostNL(
+            Customer::create()
+                ->setCollectionLocation('123456')
+                ->setCustomerCode('DEVC')
+                ->setCustomerNumber('11223344')
+                ->setContactPerson('Test')
+                ->setAddress(Address::create([
+                    'AddressType' => '02',
+                    'City'        => 'Hoofddorp',
+                    'CompanyName' => 'PostNL',
+                    'Countrycode' => 'NL',
+                    'HouseNr'     => '42',
+                    'Street'      => 'Siriusdreef',
+                    'Zipcode'     => '2132WT',
+                ]))
+                ->setGlobalPackBarcodeType('AB')
+                ->setGlobalPackCustomerCode('1234')
+            , new UsernameToken(null, 'test'),
+            true,
+            PostNL::MODE_REST
+        );
+
+        $this->service = $this->postnl->getShippingService();
+        $this->service->cache = new VoidCachePool();
+        $this->service->ttl = 1;
+    }
+
+    /**
+     * @after
+     */
+    public function logPendingRequest()
+    {
+        if (!$this->lastRequest instanceof Request) {
+            return;
+        }
+
+        global $logger;
+        if ($logger instanceof LoggerInterface) {
+            $logger->debug($this->getName()." Request\n".\GuzzleHttp\Psr7\str($this->lastRequest));
+        }
+        $this->lastRequest = null;
+    }
+
+    /**
+     * @testdox returns a valid service object
+     */
+    public function testHasValidShippingService()
+    {
+        $this->assertInstanceOf('\\ThirtyBees\\PostNL\\Service\\ShippingService', $this->service);
+    }
+
+    /**
+     * @testdox creates a valid Shipping request
+     */
+    public function testCreatesAValidShippingRequest()
+    {
+        $message = new LabellingMessage();
+
+        $this->lastRequest = $request = $this->service->buildGenerateShippingRequestREST(
+            GenerateShipping::create()
+                ->setShipments([
+                    Shipment::create()
+                        ->setAddresses([
+                            Address::create([
+                                'AddressType' => '01',
+                                'City'        => 'Utrecht',
+                                'Countrycode' => 'NL',
+                                'FirstName'   => 'Peter',
+                                'HouseNr'     => '9',
+                                'HouseNrExt'  => 'a bis',
+                                'Name'        => 'de Ruijter',
+                                'Street'      => 'Bilderdijkstraat',
+                                'Zipcode'     => '3521VA',
+                            ]),
+                            Address::create([
+                                'AddressType' => '02',
+                                'City'        => 'Hoofddorp',
+                                'CompanyName' => 'PostNL',
+                                'Countrycode' => 'NL',
+                                'HouseNr'     => '42',
+                                'Street'      => 'Siriusdreef',
+                                'Zipcode'     => '2132WT',
+                            ]),
+                        ])
+                        ->setDeliveryAddress('01')
+                        ->setDimension(new Dimension('2000'))
+                        ->setProductCodeDelivery('3085')
+                ])
+                ->setMessage($message)
+                ->setCustomer($this->postnl->getCustomer()),
+            false
+        );
+
+        $this->assertEquals([
+            'Customer'  => [
+                'Address'            => [
+                    'AddressType' => '02',
+                    'City'        => 'Hoofddorp',
+                    'CompanyName' => 'PostNL',
+                    'Countrycode' => 'NL',
+                    'HouseNr'     => '42',
+                    'Street'      => 'Siriusdreef',
+                    'Zipcode'     => '2132WT',
+                ],
+                'CollectionLocation' => '123456',
+                'ContactPerson'      => 'Test',
+                'CustomerCode'       => 'DEVC',
+                'CustomerNumber'     => '11223344',
+            ],
+            'Message'   => [
+                'MessageID'        => (string) $message->getMessageID(),
+                'MessageTimeStamp' => (string) $message->getMessageTimeStamp(),
+                'Printertype'      => 'GraphicFile|PDF',
+            ],
+            'Shipments' => [
+                0 => [
+                    'Addresses'           => [
+                        [
+                            'AddressType' => '01',
+                            'City'        => 'Utrecht',
+                            'Countrycode' => 'NL',
+                            'FirstName'   => 'Peter',
+                            'HouseNr'     => '9',
+                            'HouseNrExt'  => 'a bis',
+                            'Name'        => 'de Ruijter',
+                            'Street'      => 'Bilderdijkstraat',
+                            'Zipcode'     => '3521VA',
+                        ],
+                        [
+                            'AddressType' => '02',
+                            'City'        => 'Hoofddorp',
+                            'CompanyName' => 'PostNL',
+                            'Countrycode' => 'NL',
+                            'HouseNr'     => '42',
+                            'Street'      => 'Siriusdreef',
+                            'Zipcode'     => '2132WT',
+                        ],
+                    ],
+                    'DeliveryAddress'     => '01',
+                    'Dimension'           => [
+                        'Weight' => '2000',
+                    ],
+                    'ProductCodeDelivery' => '3085',
+                ]
+            ],
+        ],
+            json_decode((string) $request->getBody(), true), null, 0, 10, true);
+        $this->assertEquals('test', $request->getHeaderLine('apikey'));
+        $this->assertEquals('application/json;charset=UTF-8', $request->getHeaderLine('Content-Type'));
+        $this->assertEquals('application/json', $request->getHeaderLine('Accept'));
+    }
+
+    /**
+     * @testdox can generate a single shipping
+     */
+    public function testGenerateSingleShippingRest()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], json_encode([
+                'MergedLabels' => [],
+                'ResponseShipments' => [
+                    [
+                        'Barcode' => '3SDEVC201611210',
+                        'DownPartnerLocation' => [],
+                        'ProductCodeDelivery' => '3085',
+                        'Labels' => [
+                            [
+                                'Content' => static::$base64LabelContent,
+                                'Labeltype' => 'Label',
+                            ]
+                        ]
+                    ]
+                ]
+            ])),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $mockClient = new MockClient();
+        $mockClient->setHandler($handler);
+        $this->postnl->setHttpClient($mockClient);
+
+        $shipping = $this->postnl->generateShipping(
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085')
+        );
+
+        $this->assertInstanceOf('\\ThirtyBees\\PostNL\\Entity\\Response\\GenerateShippingResponse', $shipping);
+    }
+
+    /**
+     * @testdox throws exception on invalid response
+     */
+    public function testNegativeGenerateShippingInvalidResponseRest()
+    {
+        $this->expectException('ThirtyBees\\PostNL\\Exception\\ResponseException');
+
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json;charset=UTF-8'], 'asdfojasuidfo'),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $mockClient = new MockClient();
+        $mockClient->setHandler($handler);
+        $this->postnl->setHttpClient($mockClient);
+
+        $this->postnl->generateShipping(
+            (new Shipment())
+                ->setAddresses([
+                    Address::create([
+                        'AddressType' => '01',
+                        'City'        => 'Utrecht',
+                        'Countrycode' => 'NL',
+                        'FirstName'   => 'Peter',
+                        'HouseNr'     => '9',
+                        'HouseNrExt'  => 'a bis',
+                        'Name'        => 'de Ruijter',
+                        'Street'      => 'Bilderdijkstraat',
+                        'Zipcode'     => '3521VA',
+                    ]),
+                    Address::create([
+                        'AddressType' => '02',
+                        'City'        => 'Hoofddorp',
+                        'CompanyName' => 'PostNL',
+                        'Countrycode' => 'NL',
+                        'HouseNr'     => '42',
+                        'Street'      => 'Siriusdreef',
+                        'Zipcode'     => '2132WT',
+                    ]),
+                ])
+                ->setDeliveryAddress('01')
+                ->setDimension(new Dimension('2000'))
+                ->setProductCodeDelivery('3085')
+        );
+    }
+}


### PR DESCRIPTION
Adding the new PostNL Shipping webservice as described in the [documentation](https://developer.postnl.nl/browse-apis/send-and-track/shipping-webservice/)