### PR TITLE
Updated ThreeS/3S countries in PostNL.php

### DIFF
--- a/src/PostNL.php
+++ b/src/PostNL.php
@@ -106,6 +106,7 @@ class PostNL implements LoggerAwareInterface
         'AT',
         'BE',
         'BG',
+        'CY',
         'CZ',
         'DK',
         'EE',
@@ -114,6 +115,7 @@ class PostNL implements LoggerAwareInterface
         'DE',
         'GB',
         'GR',
+        'HR',
         'HU',
         'IE',
         'IT',
@@ -126,8 +128,8 @@ class PostNL implements LoggerAwareInterface
         'RO',
         'SK',
         'SI',
+        'SE',
         'ES',
-        'EE',
     ];
 
     /**


### PR DESCRIPTION
I've updated the threeS countries constant. 

Spend hours breaking my head on a test address in Sweden (the only EU address I've been testing) and I couldn't make it work. Then found out that SE was missing in the constant. 🤦  Happy that it works now!

See currrent 3S countries here https://developer.postnl.nl/browse-apis/send-and-track/products/#destination-EU